### PR TITLE
[Doppins] Upgrade dependency Flask-Migrate to ==2.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ install_requires = [
     'Flask-RESTful==0.3.3',
     'Flask-SQLAlchemy==2.1',
     'Flask-Script==2.0.5',
-    'Flask-Migrate==1.7.0',
+    'Flask-Migrate==2.0.0',
     'Flask-Bcrypt==0.7.1',
     'Flask-Principal==0.4.0',
     'Flask-Mail==0.9.1',


### PR DESCRIPTION
Hi!

A new version was just released of `Flask-Migrate`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded Flask-Migrate from `==1.7.0` to `==2.0.0`
